### PR TITLE
feat: Adds a sample Markdown file to the root page for testing

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,10 +3,7 @@
 	"singleQuote": true,
 	"trailingComma": "none",
 	"printWidth": 100,
-	"plugins": [
-		"prettier-plugin-svelte",
-		"prettier-plugin-tailwindcss"
-	],
+	"plugins": ["prettier-plugin-svelte", "prettier-plugin-tailwindcss"],
 	"tailwindStylesheet": "./src/routes/layout.css",
 	"overrides": [
 		{

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ bunx sv create --template minimal --types ts --install bun .
 bunx sv add eslint prettier tailwindcss="plugins:none" --install bun
 bunx sv add mdsvex sveltekit-adapter="adapter:static" --install bun
 ```
+
 - mdsvex: markdown 활용을 위해 임시 도입, 커스터마이징 가능 여부 확인 필요
 - sveltekit-adapter="adapter:static": SSG 적용
 
-### Run Dev 
+### Run Dev
+
 ```shell
 bun install
 bun run dev

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@sveltejs/adapter-static": "^3.0.10",
         "@sveltejs/kit": "^2.57.0",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
+        "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.2",
         "@types/node": "^22",
         "eslint": "^10.2.0",
@@ -149,6 +150,8 @@
     "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ=="],
 
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA=="],
+
+    "@tailwindcss/typography": ["@tailwindcss/typography@0.5.19", "", { "dependencies": { "postcss-selector-parser": "6.0.10" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1" } }, "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg=="],
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.0", "", { "dependencies": { "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "tailwindcss": "4.3.0" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw=="],
 
@@ -374,7 +377,7 @@
 
     "postcss-scss": ["postcss-scss@4.0.9", "", { "peerDependencies": { "postcss": "^8.4.29" } }, "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A=="],
 
-    "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
+    "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -485,5 +488,7 @@
     "svelte-eslint-parser/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
     "svelte-eslint-parser/espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "svelte-eslint-parser/postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
   }
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,7 +22,7 @@ export default defineConfig(
 		rules: {
 			// typescript-eslint strongly recommend that you do not use the no-undef lint rule on TypeScript projects.
 			// see: https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
-			"no-undef": 'off'
+			'no-undef': 'off'
 		}
 	},
 	{

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/kit": "^2.57.0",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
+		"@tailwindcss/typography": "^0.5.19",
 		"@tailwindcss/vite": "^4.2.2",
 		"@types/node": "^22",
 		"eslint": "^10.2.0",

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,5 +1,6 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
+
 declare global {
 	namespace App {
 		// interface Error {}

--- a/src/lib/posts/샘플.md
+++ b/src/lib/posts/샘플.md
@@ -1,0 +1,29 @@
+### 여기는 마크다운 영역입니다.
+
+- 리스트 스타일도 잘 나오는지 확인해보세요.
+
+*Markdown highlighting이 적용되는지 확인하는 용도의 샘플.md 입니다.*
+
+- New line 으로 분리되지 않은 경우 inline 컴포넌트로 처리되어 요소가 결합되는 현상이 발생할 수 있습니다.
+
+Looking for the essence
+
+### Initial Setup
+
+```shell
+bunx sv create --template minimal --types ts --install bun .
+bunx sv add eslint prettier tailwindcss="plugins:none" --install bun
+bunx sv add mdsvex sveltekit-adapter="adapter:static" --install bun
+```
+
+- mdsvex: markdown 활용을 위해 임시 도입, 커스터마이징 가능 여부 확인 필요
+- sveltekit-adapter="adapter:static": SSG 적용
+
+### Run Dev
+
+```shell
+bun install
+bun run dev
+```
+
+

--- a/src/lib/posts/샘플.md
+++ b/src/lib/posts/샘플.md
@@ -2,7 +2,7 @@
 
 - 리스트 스타일도 잘 나오는지 확인해보세요.
 
-*Markdown highlighting이 적용되는지 확인하는 용도의 샘플.md 입니다.*
+_Markdown highlighting이 적용되는지 확인하는 용도의 샘플.md 입니다._
 
 - New line 으로 분리되지 않은 경우 inline 컴포넌트로 처리되어 요소가 결합되는 현상이 발생할 수 있습니다.
 
@@ -25,5 +25,3 @@ bunx sv add mdsvex sveltekit-adapter="adapter:static" --install bun
 bun install
 bun run dev
 ```
-
-

--- a/src/md.d.ts
+++ b/src/md.d.ts
@@ -4,4 +4,3 @@ declare module '*.md' {
 	const component: Component;
 	export default component;
 }
-

--- a/src/md.d.ts
+++ b/src/md.d.ts
@@ -1,0 +1,7 @@
+declare module '*.md' {
+	import type { Component } from 'svelte';
+
+	const component: Component;
+	export default component;
+}
+

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,3 +1,10 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+<script lang="ts">
+	import SampleMarkdown from '$lib/posts/샘플.md';
+</script>
 
+<main class="p-6">
+	<h1 class="mb-4 text-2xl font-bold">블로그 포스트 페이지</h1>
+	<article class="prose">
+		<SampleMarkdown />
+	</article>
+</main>

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -1,1 +1,3 @@
 @import 'tailwindcss';
+
+@plugin '@tailwindcss/typography';

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -5,7 +5,7 @@ import adapter from '@sveltejs/adapter-static';
 const config = {
 	compilerOptions: {
 		// Force runes mode for the project, except for libraries. Can be removed in svelte 6.
-		runes: ({ filename }) => filename.split(/[/\\]/).includes('node_modules') ? undefined : true
+		runes: ({ filename }) => (filename.split(/[/\\]/).includes('node_modules') ? undefined : true)
 	},
 	kit: { adapter: adapter() },
 	preprocess: [mdsvex({ extensions: ['.svx', '.md'] })],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,4 +2,9 @@ import tailwindcss from '@tailwindcss/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
-export default defineConfig({ plugins: [tailwindcss(), sveltekit()] });
+export default defineConfig({
+	plugins: [tailwindcss(), sveltekit()],
+	server: {
+		port: 5173
+	}
+});


### PR DESCRIPTION
## Summary

#1 작업 계획에 따라 루트 페이지에 markdown 파일을 보여줄 수 있는지 테스트한다. 

### Changes

- svelte.config.js 설정의 preprocess 에 적용된 mdsvex 설정으로 .md 파일을 svelte 컴포넌트처럼 사용할 수 있는 것을 확인
- .md 파일의 타입을 svelte component 로 선언하여 typescript 엔진의 오류 판단에 대응, 해당 설정은 `md.d.ts` 에 적용
 