### PR TITLE
refactor/fix: Markdown 객체의 nullable 제거 및 글 정렬 기능이 올바르게 수행되도록 수정

### DIFF
--- a/src/lib/utils/markdownLoader.ts
+++ b/src/lib/utils/markdownLoader.ts
@@ -6,7 +6,7 @@ export type MarkdownModule = {
 };
 
 export type MarkdownDTO = {
-	id?: string;
+	id: string;
 	path: string;
 	metadata: MarkdownMetadata;
 	component: Component;
@@ -16,8 +16,13 @@ function loadMarkdownFiles(modules: Record<string, MarkdownModule>): MarkdownDTO
 	const markdownModules: MarkdownDTO[] = [];
 
 	for (const [path, module] of Object.entries(modules)) {
-		const id = path.split('/').at(-1)?.replace('.md', '');
+		const filename = path.split('/').at(-1);
 
+		if (!filename) {
+			throw new Error(`Failed to extract markdown filename from path: ${path}`);
+		}
+
+		const id = filename.replace('.md', '');
 		markdownModules.push(<MarkdownDTO>{
 			id: id,
 			path: path,

--- a/src/md.d.ts
+++ b/src/md.d.ts
@@ -1,6 +1,6 @@
 type MarkdownMetadata = {
 	title?: string;
-	date?: string;
+	date: string;
 	tags?: string[];
 };
 

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -29,7 +29,7 @@
 			</aside>
 			<div class="grow">
 				<ul class="text-xs font-normal text-ink-primary">
-					{#each allPosts as post (post.id)}
+					{#each sortedPosts as post (post.id)}
 						<li class="text-primary border-y-[0.5px] border-line-light py-1.5 pl-4">
 							<a href={resolve('/blog/[slug]', { slug: post.id })}>{post.metadata.title}</a>
 						</li>

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import { allPosts } from '$lib/utils/markdownLoader';
 	import { resolve } from '$app/paths';
+
+	const sortedPosts = allPosts.toSorted((a, b) => {
+		return b.metadata.date.localeCompare(a.metadata.date);
+	});
 </script>
 
 <div class="flex justify-center-safe md:mr-25">
@@ -15,7 +19,7 @@
 		<div id="post-content-box" class="flex border-y-[0.5px] border-line-bold">
 			<aside class="w-25 shrink-0">
 				<ul class="border-r-[0.5px] border-line-light text-xs font-normal text-ink-muted">
-					{#each allPosts as post (post.id)}
+					{#each sortedPosts as post (post.id)}
 						<li class="text-primary border-y-[0.5px] border-line-light py-1.5 pl-4">
 							<time>{post.metadata.date}</time>
 						</li>
@@ -27,9 +31,7 @@
 				<ul class="text-xs font-normal text-ink-primary">
 					{#each allPosts as post (post.id)}
 						<li class="text-primary border-y-[0.5px] border-line-light py-1.5 pl-4">
-							<a href={resolve('/blog/[slug]', { slug: post.id ? post.id : 'head' })}
-								>{post.metadata.title}</a
-							>
+							<a href={resolve('/blog/[slug]', { slug: post.id })}>{post.metadata.title}</a>
 						</li>
 					{/each}
 				</ul>

--- a/src/routes/release-notes/+page.svelte
+++ b/src/routes/release-notes/+page.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
 	import { allNotes } from '$lib/utils/markdownLoader';
 
-	const noteReversed = allNotes.toReversed();
+	const sortedNotes = allNotes.toSorted((a, b) => {
+		return b.metadata.date.localeCompare(a.metadata.date);
+	});
 </script>
 
 <main class="p-12">
 	<h1 class="pb-4 text-2xl font-medium">Release Notes</h1>
 	<div class="flex flex-col gap-4 text-sm">
-		{#each noteReversed as note (note.id)}
+		{#each sortedNotes as note (note.id)}
 			{@const Note = note.component}
 			<div class="flex max-w-170 gap-4 border-b-[0.5px]">
 				<time class="text-xs">{note.metadata.date}</time>


### PR DESCRIPTION
### Changes

- 마크다운 파일명이 문제를 일으키기 전에 발견됩니다.
- MarkdownDTO.id 가 required 가 되면서 null 대응 로직이 제거되었습니다.
- 이제 글 목록들이 제대로 날짜 기준으로 정렬을 시행합니다.